### PR TITLE
Refactoring `MapBoard` references

### DIFF
--- a/src/main/java/it/units/sdm/project/core/FreedomPointsCounter.java
+++ b/src/main/java/it/units/sdm/project/core/FreedomPointsCounter.java
@@ -3,6 +3,7 @@ package it.units.sdm.project.core;
 import it.units.sdm.project.Position;
 import it.units.sdm.project.Stone;
 import it.units.sdm.project.exceptions.InvalidPositionException;
+import it.units.sdm.project.interfaces.Board;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -16,11 +17,11 @@ public class FreedomPointsCounter {
 
     private final static int MAX_NUMBER_OF_STONES = 4;
     @NotNull
-    private final MapBoard<Stone> board;
+    private final Board<Stone> board;
     private final Set<FreedomLine> blackFreedomLines = new HashSet<>();
     private final Set<FreedomLine> whiteFreedomLines = new HashSet<>();
 
-    public FreedomPointsCounter(@NotNull MapBoard<Stone> board) {
+    public FreedomPointsCounter(@NotNull Board<Stone> board) {
         this.board = board;
     }
 

--- a/src/main/java/it/units/sdm/project/core/MapBoard.java
+++ b/src/main/java/it/units/sdm/project/core/MapBoard.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 public class MapBoard<P extends Stone> implements Board<P> {
 
-    private final SortedMap<Position, MapBoardCell<P>> cells = new TreeMap<>();
+    private final Map<Position, MapBoardCell<P>> cells = new TreeMap<>();
     private final int numberOfRows;
     private final int numberOfColumns;
 

--- a/src/main/java/it/units/sdm/project/core/MapBoard.java
+++ b/src/main/java/it/units/sdm/project/core/MapBoard.java
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-public class MapBoard<P extends Stone> implements Iterable<Position>, Board<P> {
+public class MapBoard<P extends Stone> implements Board<P> {
 
     private final SortedMap<Position, MapBoardCell<P>> cells = new TreeMap<>();
     private final int numberOfRows;

--- a/src/main/java/it/units/sdm/project/interfaces/Board.java
+++ b/src/main/java/it/units/sdm/project/interfaces/Board.java
@@ -4,7 +4,7 @@ import it.units.sdm.project.Position;
 import org.jetbrains.annotations.NotNull;
 
 
-public interface Board<P> {
+public interface Board<P> extends Iterable<Position> {
     int getNumberOfRows();
     int getNumberOfColumns();
     boolean isCellOccupied(@NotNull Position position);

--- a/src/test/java/FreedomPointsCounterTests.java
+++ b/src/test/java/FreedomPointsCounterTests.java
@@ -2,6 +2,7 @@ import it.units.sdm.project.core.MapBoard;
 import it.units.sdm.project.core.FreedomPointsCounter;
 import it.units.sdm.project.Position;
 import it.units.sdm.project.Stone;
+import it.units.sdm.project.interfaces.Board;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -16,9 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FreedomPointsCounterTests {
 
-    private static @NotNull MapBoard<Stone> parseBoardFromString(@NotNull String printedBoard, int numberOfRows, int numberOfColumns) {
+    private static @NotNull Board<Stone> parseBoardFromString(@NotNull String printedBoard, int numberOfRows, int numberOfColumns) {
         Scanner scanner = new Scanner(printedBoard);
-        MapBoard<Stone> board = new MapBoard<>(numberOfRows, numberOfColumns);
+        Board<Stone> board = new MapBoard<>(numberOfRows, numberOfColumns);
         while (scanner.hasNextLine()) {
             if (scanner.hasNextInt()) {
                 int currentRow = scanner.nextInt();
@@ -51,7 +52,7 @@ public class FreedomPointsCounterTests {
                         + " 2 -  -  -  -  -  -  -  -\n"
                         + " 1 -  -  -  -  -  -  -  -\n"
                         + "   A  B  C  D  E  F  G  H";
-        MapBoard<Stone> board = parseBoardFromString(printedBoard, 8, 8);
+        Board<Stone> board = parseBoardFromString(printedBoard, 8, 8);
         assertEquals(printedBoard, board.toString());
     }
 
@@ -132,7 +133,7 @@ public class FreedomPointsCounterTests {
     @ParameterizedTest
     @MethodSource("printedBoardsProvider")
     void testGetWinner(String printedBoard, int numberOfRows, int numberOfColumns, int blackScore, int whiteScore) {
-        MapBoard<Stone> board = parseBoardFromString(printedBoard, numberOfRows, numberOfColumns);
+        Board<Stone> board = parseBoardFromString(printedBoard, numberOfRows, numberOfColumns);
         FreedomPointsCounter freedomPointsCounter = new FreedomPointsCounter(board);
         freedomPointsCounter.count();
         Assertions.assertEquals(freedomPointsCounter.getBlackPlayerScore(), blackScore);


### PR DESCRIPTION
Closing #59. This issue also brought to light the need for the `Board` interface to extend the `Iterable<Position>` interface. We should discuss whether it makes more sense to iterate through the generic pieces of type `P` rather than through `Position`s, similarly to the java `List<E>` interface.