### PR TITLE
Last refactoring

### DIFF
--- a/core/src/it/units/sdm/project/board/MapBoard.java
+++ b/core/src/it/units/sdm/project/board/MapBoard.java
@@ -75,8 +75,9 @@ public class MapBoard<P extends Piece> implements Board<P> {
     /**
      * Generates a {@link String} representation of the {@link Board}. The {@link Board} is displayed here as a chess board,
      * with letters indicating columns and numbers indicating rows. Free cells are marked with a - character,
-     * while cells occupied by the white {@link it.units.sdm.project.game.Player} are marked with a W
-     * and cells occupied by the black {@link it.units.sdm.project.game.Player} are marked with a B.
+     * while cells occupied are displayed with {@link Object#toString()}. In order to properly visualize
+     * the {@link Board}, the {@link Piece}s used must have a single character string representation by overriding
+     * the {@link Object#toString()}.
      *
      * @return The {@link Board}'s {@link String} representation
      */

--- a/core/src/it/units/sdm/project/board/MapBoard.java
+++ b/core/src/it/units/sdm/project/board/MapBoard.java
@@ -86,11 +86,12 @@ public class MapBoard<P extends Piece> implements Board<P> {
         StringBuilder sb = new StringBuilder();
         for (int i = boardSize - 1; i >= 0; i--) {
             for (int j = 0; j < boardSize; j++) {
+                Position currentPosition = Position.fromCoordinates(i, j);
                 if (isFirstColumn(j)) {
                     sb.append(currentRowLabel(i));
                 }
-                if (isCellOccupied(Position.fromCoordinates(i, j))) {
-                    sb.append(getPiece(Position.fromCoordinates(i, j)));
+                if (isCellOccupied(currentPosition)) {
+                    sb.append(getPiece(currentPosition));
                 } else {
                     sb.append("-");
                 }

--- a/core/src/it/units/sdm/project/board/gui/TileClickListener.java
+++ b/core/src/it/units/sdm/project/board/gui/TileClickListener.java
@@ -5,6 +5,7 @@ import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.*;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import it.units.sdm.project.board.Position;
+import it.units.sdm.project.game.BoardGame;
 import it.units.sdm.project.game.gui.FreedomGame;
 import org.jetbrains.annotations.NotNull;
 
@@ -13,16 +14,16 @@ import org.jetbrains.annotations.NotNull;
  */
 public class TileClickListener extends ClickListener {
     @NotNull
-    private final FreedomGame game;
+    private final BoardGame<?> game;
 
     /**
      * Creates a new listener to be used with a {@link it.units.sdm.project.board.Board}. By default,
      * the listener will simply execute the {@link FreedomGame#nextMove(Position)} method from the {@link FreedomGame}
      * interface using the clicked tile's {@link Position}.
      * If a different behaviour is expected, the {@link ClickListener#clicked(InputEvent, float, float)} method should be overridden.
-     * @param game The {@link FreedomGame} instance on which to listen for tile click events
+     * @param game The {@link BoardGame} instance on which to listen for tile click events
      */
-    public TileClickListener(@NotNull FreedomGame game) {
+    public TileClickListener(@NotNull BoardGame<?> game) {
         this.game = game;
     }
 
@@ -34,7 +35,7 @@ public class TileClickListener extends ClickListener {
      */
     @Override
     public void clicked(@NotNull InputEvent event, float x, float y) {
-        GuiBoard<GuiStone> board = (GuiBoard<GuiStone>) game.getBoard();
+        GuiBoard<?> board = (GuiBoard<?>) game.getBoard();
         Cell<Actor> cell = board.getCell(event.getListenerActor());
         game.nextMove(board.fromTileCoordinatesToBoardPosition(cell.getRow(), cell.getColumn()));
         super.clicked(event, x, y);

--- a/core/src/it/units/sdm/project/board/gui/TileClickListener.java
+++ b/core/src/it/units/sdm/project/board/gui/TileClickListener.java
@@ -14,17 +14,17 @@ import org.jetbrains.annotations.NotNull;
  */
 public class TileClickListener extends ClickListener {
     @NotNull
-    private final BoardGame<?> game;
+    private final BoardGame<?> boardGame;
 
     /**
      * Creates a new listener to be used with a {@link it.units.sdm.project.board.Board}. By default,
      * the listener will simply execute the {@link FreedomGame#nextMove(Position)} method from the {@link FreedomGame}
      * interface using the clicked tile's {@link Position}.
      * If a different behaviour is expected, the {@link ClickListener#clicked(InputEvent, float, float)} method should be overridden.
-     * @param game The {@link BoardGame} instance on which to listen for tile click events
+     * @param boardGame The {@link BoardGame} instance on which to listen for tile click events
      */
-    public TileClickListener(@NotNull BoardGame<?> game) {
-        this.game = game;
+    public TileClickListener(@NotNull BoardGame<?> boardGame) {
+        this.boardGame = boardGame;
     }
 
     /**
@@ -35,9 +35,9 @@ public class TileClickListener extends ClickListener {
      */
     @Override
     public void clicked(@NotNull InputEvent event, float x, float y) {
-        GuiBoard<?> board = (GuiBoard<?>) game.getBoard();
+        GuiBoard<?> board = (GuiBoard<?>) boardGame.getBoard();
         Cell<Actor> cell = board.getCell(event.getListenerActor());
-        game.nextMove(board.fromTileCoordinatesToBoardPosition(cell.getRow(), cell.getColumn()));
+        boardGame.nextMove(board.fromTileCoordinatesToBoardPosition(cell.getRow(), cell.getColumn()));
         super.clicked(event, x, y);
     }
 }

--- a/core/src/it/units/sdm/project/game/BoardGame.java
+++ b/core/src/it/units/sdm/project/game/BoardGame.java
@@ -38,9 +38,9 @@ public interface BoardGame<P extends Piece> {
 
     /**
      * Plays the next {@link Move} in this {@link BoardGame}
-     * @param position The chosen {@link Position} for the next {@link Move}
+     * @param playerChosenPosition The chosen {@link Position} for the next {@link Move}
      */
-    void nextMove(@NotNull Position position);
+    void nextMove(@NotNull Position playerChosenPosition);
 
     /**
      * Returns the {@link Player} who's playing next

--- a/core/src/it/units/sdm/project/game/FreedomLine.java
+++ b/core/src/it/units/sdm/project/game/FreedomLine.java
@@ -125,24 +125,24 @@ public class FreedomLine {
         throw new InvalidPositionException("The next position is not adjacent to the last stone of this line");
     }
 
-    private boolean isHorizontal(@NotNull Position position) {
-        if(cellPositions.first().getRow() == position.getRow() && cellPositions.first().getColumn() == position.getColumn() + 1) return true;
-        return cellPositions.last().getRow() == position.getRow() && cellPositions.last().getColumn() == position.getColumn() - 1;
+    private boolean isHorizontal(@NotNull Position nextPosition) {
+        if(cellPositions.first().getRow() == nextPosition.getRow() && cellPositions.first().getColumn() == nextPosition.getColumn() + 1) return true;
+        return cellPositions.last().getRow() == nextPosition.getRow() && cellPositions.last().getColumn() == nextPosition.getColumn() - 1;
     }
 
-    private boolean isVertical(@NotNull Position position) {
-        if(cellPositions.first().getColumn() == position.getColumn() && cellPositions.first().getRow() - 1 == position.getRow())  return true;
-        return cellPositions.last().getColumn() == position.getColumn() && cellPositions.last().getRow() + 1 == position.getRow();
+    private boolean isVertical(@NotNull Position nextPosition) {
+        if(cellPositions.first().getColumn() == nextPosition.getColumn() && cellPositions.first().getRow() - 1 == nextPosition.getRow())  return true;
+        return cellPositions.last().getColumn() == nextPosition.getColumn() && cellPositions.last().getRow() + 1 == nextPosition.getRow();
     }
 
-    private boolean isDiagonalLeft(@NotNull Position position) {
-        if(cellPositions.first().getColumn() == position.getColumn() - 1 && cellPositions.first().getRow() == position.getRow() + 1) return true;
-        return cellPositions.last().getColumn() == position.getColumn() + 1 && cellPositions.last().getRow() == position.getRow() - 1;
+    private boolean isDiagonalLeft(@NotNull Position nextPosition) {
+        if(cellPositions.first().getColumn() == nextPosition.getColumn() - 1 && cellPositions.first().getRow() == nextPosition.getRow() + 1) return true;
+        return cellPositions.last().getColumn() == nextPosition.getColumn() + 1 && cellPositions.last().getRow() == nextPosition.getRow() - 1;
     }
 
-    private boolean isDiagonalRight(@NotNull Position position) {
-        if(cellPositions.first().getColumn() == position.getColumn() + 1 && cellPositions.first().getRow() == position.getRow() + 1) return true;
-        return cellPositions.last().getColumn() == position.getColumn() - 1 && cellPositions.last().getRow() == position.getRow() - 1;
+    private boolean isDiagonalRight(@NotNull Position nextPosition) {
+        if(cellPositions.first().getColumn() == nextPosition.getColumn() + 1 && cellPositions.first().getRow() == nextPosition.getRow() + 1) return true;
+        return cellPositions.last().getColumn() == nextPosition.getColumn() - 1 && cellPositions.last().getRow() == nextPosition.getRow() - 1;
     }
 
     /**


### PR DESCRIPTION
Main changes:
- `TileClickListener` has `BoardGame` field instead of `FreedomGame` in order to generalize the class
- `toString` documentation of the `MapBoard` class: `MapBoard` class can handle `Piece`s which `toString` isn't overriden, so, I added a warning of how should be overriden the method `toString` in order to properly display the `MapBoard`
- `nextMove` argument name refactoring 
- another name refactoring in the `FreedomLine`
  